### PR TITLE
fix:/timer-presets

### DIFF
--- a/src/components/dashboard/pomodoro/PomodoroControl.tsx
+++ b/src/components/dashboard/pomodoro/PomodoroControl.tsx
@@ -76,8 +76,8 @@ function PomodoroControl() {
 
   const handleTimerReset = () => {
     setIsTimerRunning(false)
-    setTime(TIMER_PRESETS[0].value)
-    setActiveButton(TIMER_PRESETS[0].display)
+    setTime(TIMER_PRESETS.find(preset => preset.display === isActiveButton)?.value || DEFAULT_TIME);
+    setActiveButton(isActiveButton)
     // change to app name
     document.title = "Time Management Tool"
   }


### PR DESCRIPTION
Fixes: #37 

### Checklist

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox
- [ ] Branch is up-to-date with the branch to be merged with, i.e., `main`
- [ ] Code is cleaned up and formatted

### Summary of changes

In the pomodoro timer when the tab is set to Short break or long break and the timer is on if we try to reset the timer it resets to 25 mins not to 5 or 30.

### Video
[Screencast from 16-01-25 10:48:31 AM IST.webm](https://github.com/user-attachments/assets/7c96c9de-c027-46ee-b9e5-7e059ebc14c1)

